### PR TITLE
Added node cast in scene template to support non-node types

### DIFF
--- a/SourceGenerators/Scene/SceneTreeTemplate.sbncs
+++ b/SourceGenerators/Scene/SceneTreeTemplate.sbncs
@@ -13,7 +13,7 @@
 {{NSIndent}}{{NSIndent}}{{NSIndent}}{{NSIndent}}    {{node.MemberName}} = lowerNameToNode[lowerName] as {{node.Type}};
 {{NSIndent}}{{NSIndent}}{{NSIndent}}{{NSIndent}}    if ({{node.MemberName}} != null)
 {{NSIndent}}{{NSIndent}}{{NSIndent}}{{NSIndent}}    {
-{{NSIndent}}{{NSIndent}}{{NSIndent}}{{NSIndent}}{{NSIndent}}    GD.PushWarning($"Assigned member {nameof({{node.MemberName}})} to node {({{node.MemberName}}).Name} in {filename} as a best-guess.");
+{{NSIndent}}{{NSIndent}}{{NSIndent}}{{NSIndent}}{{NSIndent}}    GD.PushWarning($"Assigned member {nameof({{node.MemberName}})} to node {((Node)({{node.MemberName}})).Name} in {filename} as a best-guess.");
 {{NSIndent}}{{NSIndent}}{{NSIndent}}{{NSIndent}}    }
 {{NSIndent}}{{NSIndent}}{{NSIndent}}    }
 {{NSIndent}}{{NSIndent}}{{NSIndent}}    if ({{node.MemberName}} == null)


### PR DESCRIPTION
Closes #12 

The scene template assumes that the target member is a descendant of `Node`, so when the attributed value is not a Node, the generated code will cause compilation to fail. Adding this cast fixes this and allows interface type to be used instead of strictly `Node` types.

However, this also allows any arbitrary type to be used as well, potentially causing a runtime cast error. However, seeing that there are already no checks to detect if the attributed member is a Node (assuming the above error is just a coincidence), I think this shouldn't be a big issue. 
If needed, some harder compile-time checks (if the attributed member inherits Node or is an interface) could be added later.